### PR TITLE
Move adminhtml menu links under Content

### DIFF
--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -19,8 +19,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-    	<add id="Bss_Megamenu::megamenu_main" title="Bss Commerce" module="Bss_Megamenu" sortOrder="15" resource="Bss_Megamenu::megamenu_main"/>
-        <add id="Bss_Megamenu::menu_head_manage" title="Mega Menu" module="Bss_Megamenu" sortOrder="10" parent="Bss_Megamenu::megamenu_main" resource="Bss_Megamenu::menu_head_manage"/>
+        <add id="Bss_Megamenu::menu_head_manage" title="Mega Menu" module="Bss_Megamenu" sortOrder="50" parent="Magento_Backend::content" resource="Bss_Megamenu::menu_head_manage"/>
         <add id="Bss_Megamenu::megamenu" title="Manage Menu Items" translate="title" module="Bss_Megamenu" sortOrder="50" parent="Bss_Megamenu::menu_head_manage" action="megamenu/category/" resource="Bss_Megamenu::megamenu"/>
         <add id="Bss_Megamenu::config" title="Configurations" translate="title" module="Bss_Megamenu" sortOrder="50" parent="Bss_Megamenu::menu_head_manage" action="adminhtml/system_config/edit/section/megamenu" resource="Bss_Megamenu::config"/>
     </menu>


### PR DESCRIPTION
Would it be possible to move the adminhtml menu under Content tab? Our customers care about usability and filling the top level left menu with business-specific items in my opinion does not help it.

![mega-menu](https://user-images.githubusercontent.com/12877644/60696041-ae954780-9eec-11e9-9559-e4362401b63b.png)
